### PR TITLE
Increase the value of a kernel parameter to stop NVMe remounts

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -30,8 +30,8 @@ platforms:
   # Ansible currently insists on installing python2-dnf, which does
   # not exist in Fedora 30.  Until that is resolved, we can't use
   # Fedora 30.
-  # - name: fedora29_systemd
-  #   image: geerlingguy/docker-fedora29-ansible:latest
+  # - name: fedora30_systemd
+  #   image: geerlingguy/docker-fedora30-ansible:latest
   #   privileged: yes
   #   volumes:
   #     - /sys/fs/cgroup:/sys/fs/cgroup:ro

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -6,37 +6,17 @@ driver:
 lint:
   name: yamllint
 platforms:
-  - name: debian9_systemd
-    image: geerlingguy/docker-debian9-ansible:latest
-    privileged: yes
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    command: /lib/systemd/systemd
-    pre_build_image: yes
-  - name: debian10_systemd
-    image: geerlingguy/docker-debian10-ansible:latest
-    privileged: yes
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    command: /lib/systemd/systemd
-    pre_build_image: yes
-  - name: fedora29_systemd
-    image: geerlingguy/docker-fedora29-ansible:latest
-    privileged: yes
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    command: /lib/systemd/systemd
-    pre_build_image: yes
+  - name: debian9
+    image: debian:stretch-slim
+  - name: debian10
+    image: debian:buster-slim
+  - name: fedora29
+    image: fedora:29
   # Ansible currently insists on installing python2-dnf, which does
   # not exist in Fedora 30.  Until that is resolved, we can't use
   # Fedora 30.
-  # - name: fedora30_systemd
-  #   image: geerlingguy/docker-fedora30-ansible:latest
-  #   privileged: yes
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:ro
-  #   command: /lib/systemd/systemd
-  #   pre_build_image: yes
+  # - name: fedora30
+  #   image: fedora:30
   - name: amazon2018.03
     image: amazonlinux:2018.03
 provisioner:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -6,14 +6,37 @@ driver:
 lint:
   name: yamllint
 platforms:
-  - name: debian9
-    image: debian:stretch-slim
-  - name: debian10
-    image: debian:buster-slim
-  - name: fedora29
-    image: fedora:29
-  # - name: fedora30
-  #   image: fedora:30
+  - name: debian9_systemd
+    image: geerlingguy/docker-debian9-ansible:latest
+    privileged: yes
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    command: /lib/systemd/systemd
+    pre_build_image: yes
+  - name: debian10_systemd
+    image: geerlingguy/docker-debian10-ansible:latest
+    privileged: yes
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    command: /lib/systemd/systemd
+    pre_build_image: yes
+  - name: fedora29_systemd
+    image: geerlingguy/docker-fedora29-ansible:latest
+    privileged: yes
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    command: /lib/systemd/systemd
+    pre_build_image: yes
+  # Ansible currently insists on installing python2-dnf, which does
+  # not exist in Fedora 30.  Until that is resolved, we can't use
+  # Fedora 30.
+  # - name: fedora29_systemd
+  #   image: geerlingguy/docker-fedora29-ansible:latest
+  #   privileged: yes
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:ro
+  #   command: /lib/systemd/systemd
+  #   pre_build_image: yes
   - name: amazon2018.03
     image: amazonlinux:2018.03
 provisioner:

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -1,0 +1,9 @@
+---
+# The kmod package is installed anywhere we would be applying this
+# Ansible role
+- name: Prepare
+  hosts: all
+  tasks:
+    - name: Install kmod
+      package:
+        name: kmod

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -14,3 +14,17 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 def test_packages(host, pkg):
     """Test that the appropriate packages were installed."""
     assert host.package(pkg).is_installed
+
+
+@pytest.mark.parametrize(
+    "file,content",
+    [("/etc/sysctl.d/nvme_core_io_timeout.conf", r"^nvme_core.io_timeout=[0-9]*$")],
+)
+def test_files_content(host, file, content):
+    """Test that config files were modified as expected."""
+    f = host.file(file)
+
+    # This kernel configuration setting is already present in Amazon Linux
+    if host.system_info.distribution != "amzn":
+        assert f.exists
+        assert f.contains(content)

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -18,7 +18,7 @@ def test_packages(host, pkg):
 
 @pytest.mark.parametrize(
     "file,content",
-    [("/etc/sysctl.d/nvme_core_io_timeout.conf", r"^nvme_core.io_timeout=[0-9]*$")],
+    [("/etc/modprobe.d/nvme_core.conf", r"^options nvme_core io_timeout=[0-9]*$")],
 )
 def test_files_content(host, file, content):
     """Test that config files were modified as expected."""

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,7 +26,7 @@
 # for more details.
 - name: Set NVMe timeout kernel parameter to maximum value
   template:
-    src: nvme_core_io_timeout.conf.j2
-    dest: /etc/sysctl.d/nvme_core_io_timeout.conf
+    src: nvme_core.conf.j2
+    dest: /etc/modprobe.d/nvme_core.conf
     mode: 0400
   when: ansible_distribution != 'Amazon'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,3 +4,29 @@
 - name: Install nvme-cli
   package:
     name: nvme-cli
+
+- name: Set NVMe timeout value to use (Debian Stretch)
+  set_fact:
+    timeout_value: 255
+  when:
+    - ansible_facts['distribution'] == 'Debian'
+    - ansible_facts['distribution_major_version'] == '9'
+
+- name: Set NVMe timeout value to use (not Debian Stretch)
+  set_fact:
+    timeout_value: 4294967295
+  when:
+    - ansible_facts['distribution'] != 'Debian' or ansible_facts['distribution_major_version'] != '9'
+
+# Setting this kernel parameter to a high value fixes the bug where
+# NVMe volumes occassionally fail and are mounted read-only.
+#
+# See
+# https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/nvme-ebs-volumes.html#timeout-nvme-ebs-volumes
+# for more details.
+- name: Set NVMe timeout kernel parameter to maximum value
+  template:
+    src: nvme_core_io_timeout.conf.j2
+    dest: /etc/sysctl.d/nvme_core_io_timeout.conf
+    mode: 0400
+  when: ansible_distribution != 'Amazon'

--- a/templates/nvme_core.conf.j2
+++ b/templates/nvme_core.conf.j2
@@ -5,4 +5,4 @@
 # See
 # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/nvme-ebs-volumes.html#timeout-nvme-ebs-volumes
 # for more details.
-nvme_core.io_timeout={{ timeout_value }}
+options nvme_core io_timeout={{ timeout_value }}

--- a/templates/nvme_core_io_timeout.conf.j2
+++ b/templates/nvme_core_io_timeout.conf.j2
@@ -1,0 +1,8 @@
+# Setting this kernel parameter to a high value fixes the bug where
+# NVMe volumes occassionally fail and are mounted read-only.  This
+# value is the highest accepted by all newer Linux kernels.
+#
+# See
+# https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/nvme-ebs-volumes.html#timeout-nvme-ebs-volumes
+# for more details.
+nvme_core.io_timeout={{ timeout_value }}


### PR DESCRIPTION
## 🗣 Description

Setting the `nvme_core.io_timeout` kernel parameter to the highest allowable value fixes a bug where NVMe volumes occasionally fail and are mounted read-only.

See [this link](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/nvme-ebs-volumes.html#timeout-nvme-ebs-volumes) for more details.

## 💭 Motivation and Context

We have been seeing cases where NVMe volumes in AWS sporadically encounter a timeout condition and are remounted read-only.  This behavior interferes with the operation of the Cyber Hygiene commander, for example, and must cease.

## 🧪 Testing

I added a test to verify that the molecule code functions as intended.

TODO: I intend to deploy an image for each OS that we use and verify that the kernel parameter is set correctly.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
