### PR TITLE
Bugfix/fix broken build

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,7 @@
 # These owners will be the default owners for everything in the
 # repo. Unless a later match takes precedence, these owners will be
 # requested for review when someone opens a pull request.
-* @dav3r @jsf9k
+* @dav3r @jsf9k @mcdonnnj
 
 # These folks own any files in the .github directory at the root of
 # the repository and any of its subdirectories.

--- a/molecule/default/python.yml
+++ b/molecule/default/python.yml
@@ -1,9 +1,8 @@
 ---
 - hosts: all
-  name: Install pip3/python3 and remove pip2/python2
+  name: Install pip3/python3
   become: yes
   become_method: sudo
   roles:
     - pip
     - python
-    - remove_python2

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -3,7 +3,5 @@
   name: pip
 - src: https://github.com/cisagov/ansible-role-python
   name: python
-- src: https://github.com/cisagov/ansible-role-remove-python2
-  name: remove_python2
 - src: https://github.com/cisagov/ansible-role-upgrade
   name: upgrade


### PR DESCRIPTION
## 🗣 Description ##

This pull request removes the [cisagov/ansible-role-remove-python2](https://github.com/cisagov/ansible-role-remove-python2) Ansible role from the Molecule `prepare` stage.

## 💭 Motivation and context ##

This role is no longer necessary, since Ansible no longer defaults to `/usr/bin/python`, and it breaks the Debian Stretch build.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.